### PR TITLE
:bug: fix: remove unnecessary rounding

### DIFF
--- a/.changeset/giant-scissors-attack.md
+++ b/.changeset/giant-scissors-attack.md
@@ -1,0 +1,5 @@
+---
+"neotoc": patch
+---
+
+Fix bug(#15) in auto-scrolling.

--- a/packages/neotoc/src/index.ts
+++ b/packages/neotoc/src/index.ts
@@ -640,12 +640,8 @@ export default function neotoc({
       const bottom = y2Min + scrolledY - tocBodyTop - borderTopWidth;
 
       scrollContainerScrollTop = scrollContainer.scrollTop;
-      topInUnfoldedState = Math.round(
-        y1Max + scrolledY - tocBodyTop - borderTopWidth,
-      );
-      bottomInUnfoldedState = Math.round(
-        y2Max + scrolledY - tocBodyTop - borderTopWidth,
-      );
+      topInUnfoldedState = y1Max + scrolledY - tocBodyTop - borderTopWidth;
+      bottomInUnfoldedState = y2Max + scrolledY - tocBodyTop - borderTopWidth;
 
       // See it's definition to be clear about its purpose
       runConditionally(() => {


### PR DESCRIPTION
It fixes the bug (#15) that causes inconsistent auto-scrolling via any other method than dragging the scroll container's scrollbar.

It took me the whole day figure this out!!! It turns out that `Math.round` was the culprit.